### PR TITLE
Store external masses as reference. Fix #4

### DIFF
--- a/ProcessExporter.py
+++ b/ProcessExporter.py
@@ -349,7 +349,7 @@ class OneProcessExporterMoMEMta(object):
         constructor_lines.append("// Set external particle masses for this matrix element")
 
         for part in matrix_element.get_external_wavefunctions():
-            constructor_lines.append("mME.push_back(params->%s);" % part.get('mass'))
+            constructor_lines.append("mME.push_back(std::ref(params->%s));" % part.get('mass'))
 
         return "\n".join(constructor_lines)
 

--- a/Template/process.h
+++ b/Template/process.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <utility>
 #include <map> 
+#include <functional>
 
 #include <Parameters_%(model_name)s.h>
 #include <SubProcess.h>

--- a/Template/process_class.inc
+++ b/Template/process_class.inc
@@ -36,7 +36,7 @@
             std::shared_ptr<Parameters_%(model_name)s> params; 
     
             // vector with external particle masses
-            std::vector<double> mME;
+            std::vector<std::reference_wrapper<double>> mME;
     
             // vector with momenta (to be changed each event)
             double* momenta[%(nexternal)s];


### PR DESCRIPTION
Resulting ME still builds, but I did not run-tested
