### PR TITLE
Easier way to look for MoMEMta

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MoMEMta - MadGraph Matrix Element Exporter
 ## Requirements
 
 - Python >= 2.7
-- MoMEMta >= 0.1.0 (and its requirements, such as LHAPDF, Boost)
+- MoMEMta >= 0.1.0
 - A C++-11 capable compiler
 
 **Note**: MoMEMta needs to be installed on the system (locally or globally), cf. MoMEMta documentation.
@@ -39,8 +39,7 @@ make -j 4
 This generates a shared library that can be dynamically loaded by MoMEMta (using the `load_modules()` function in the Lua config file).
 
 The following options are available when configuring the the build (when running `cmake ..`):
-- `-DMOMEMTA_INCLUDE_DIR=(path)`: Path to the `include` directory of your installation of MoMEMta. Use this if your version of MoMEMta was installed locally and not in your system directories
-- `-DBOOST_ROOT=(path)`: Use specific Boost version (path to install directory)
+- `-DCMAKE_PREFIX_PATH=(path)`: Path to the installation of MoMEMta. **Must be specified** if your version of MoMEMta is installed locally and not in your system directories
 
 The matrix element has a name assigned to it, of type `myHappyME_P1_Sigma_pp_ttx_...`: 
 this is the name to use when defining the matrix element module in your Lua config file. 

--- a/Template/CMakeLists.txt
+++ b/Template/CMakeLists.txt
@@ -22,16 +22,8 @@ cmake_minimum_required(VERSION 2.8)
 
 project(%(dir_name)s CXX)
 
-find_path(
-    MOMEMTA_INCLUDE_DIR 
-    NAMES momemta/MoMEMta.h
-    DOC "MoMEMta include dir"
-)
-
-set(MOMEMTA_INCLUDE_DIRS ${MOMEMTA_INCLUDE_DIR})
-
-set(Boost_NO_BOOST_CMAKE ON)
-find_package(Boost REQUIRED log)
+# Find MoMEMta
+find_package(MoMEMta CONFIG REQUIRED)
 
 # Flags necessary to ensure complex arithmetic performances on-par with
 # Fortran code:
@@ -39,9 +31,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -std=c++11 -O3 -fcx
 
 file(GLOB_RECURSE SOURCES "*.cc")
 
-include_directories(${MOMEMTA_INCLUDE_DIRS})
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 include_directories("include")
 %(include_subprocs_list)s
 
 add_library(me_%(dir_name)s SHARED ${SOURCES})
+target_link_libraries(me_%(dir_name)s momemta::momemta)


### PR DESCRIPTION
Update the exporter to use new feature introduced by https://github.com/MoMEMta/MoMEMta/pull/115. I also removed the find_package for boost log, since it's not needed anymore.

I'd appreciate a double-check. It's working fine on my laptop, but we never know :)
